### PR TITLE
remove default namespace

### DIFF
--- a/openshift/route.yaml
+++ b/openshift/route.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     chart: cloudnativesampleapp-1.0.0
   name: cloudnative-sample
-  namespace: default
 spec:
   port:
     targetPort: 9080


### PR DESCRIPTION
Remove default namespace so it will get deployed to proper namespace as defined by Argo CD